### PR TITLE
Change npm i to npm ci

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -341,7 +341,7 @@ Start by cloning and installing that library in the tutorial folder:
 ```shell
 git clone https://github.com/inrupt/solid-client-authn-js.git
 cd solid-client-authn-js
-npm install
+npm ci
 ```
 
 This library contains both implementations for authenticating using Node.js and JavaScript in the browser.
@@ -350,7 +350,7 @@ We use one of these example implementations here.
 After installation is complete, use the following commands to install and start this client:
 ```shell
 cd packages/browser/examples/demoClientApp
-npm install
+npm ci
 npm start
 ```
 This will start the demo application which you can see at http://localhost:3001/.

--- a/getting-started.md
+++ b/getting-started.md
@@ -60,7 +60,7 @@ You do this by cloning the server from the git repository and installing it:
 ```shell
 git clone https://github.com/CommunitySolidServer/CommunitySolidServer.git
 cd CommunitySolidServer
-npm install
+npm ci
 ```
 
 After that you start the server by running the following command from the same folder:


### PR DESCRIPTION
Note that when you run `npm install` that will actually re-resolve all dependencies updating all of them to the most advanced versions supported. This means that what users will install will *not* be what is in the lockfile and therefore not what was tested by yall. The correct thing is `npm ci`